### PR TITLE
Compilation fails for new glibc / gcc versions

### DIFF
--- a/byte_rchr.c
+++ b/byte_rchr.c
@@ -1,5 +1,7 @@
 /* Public domain. */
 
+#include <string.h>
+
 #include "byte.h"
 #include "hasmemrchr.h"
 

--- a/conf-cc
+++ b/conf-cc
@@ -1,3 +1,3 @@
-gcc -O2 -Wall -Wshadow -Wcast-align -Wwrite-strings
+gcc -O2 -Wall -Wshadow -Wcast-align -Wwrite-strings -D_GNU_SOURCE
 
 This will be used to compile .c files.

--- a/tryshsgr.c
+++ b/tryshsgr.c
@@ -7,19 +7,19 @@
 
 int main()
 {
-	gid_t *x;
-	long ngroups_max;
+  gid_t *x;
+  long ngroups_max;
   
-	ngroups_max = sysconf(_SC_NGROUPS_MAX) + 1;
-	x = (gid_t *)malloc(ngroups_max *sizeof(gid_t));
+  ngroups_max = sysconf(_SC_NGROUPS_MAX) + 1;
+  x = (gid_t *)malloc(ngroups_max *sizeof(gid_t));
   
-    x[0] = x[1] = 1;
-    if (getgroups(ngroups_max,x) == 0) if (setgroups(ngroups_max,x) == -1) _exit(1);
-  
-    if (getgroups(ngroups_max,x) == -1) _exit(1);
-    if (x[1] != 1) _exit(1);
-    x[1] = 2;
-    if (getgroups(ngroups_max,x) == -1) _exit(1);
-    if (x[1] != 2) _exit(1);
-    _exit(0);
+  x[0] = x[1] = 1;
+  if (getgroups(ngroups_max,x) == 0) if (setgroups(ngroups_max,x) == -1) _exit(1);
+
+  if (getgroups(ngroups_max,x) == -1) _exit(1);
+  if (x[1] != 1) _exit(1);
+  x[1] = 2;
+  if (getgroups(ngroups_max,x) == -1) _exit(1);
+  if (x[1] != 2) _exit(1);
+  _exit(0);
 }

--- a/tryshsgr.c
+++ b/tryshsgr.c
@@ -14,13 +14,9 @@ int main()
 	x = (gid_t *)malloc(ngroups_max *sizeof(gid_t));
   
     x[0] = x[1] = 1;
-    if (getgroups(ngroups_max,x) == 0) {
-        if (setgroups(ngroups_max,x) == -1) _exit(1);
-    }
+    if (getgroups(ngroups_max,x) == 0) if (setgroups(ngroups_max,x) == -1) _exit(1);
   
-    if (getgroups(ngroups_max,x) == -1) {
-        _exit(1);
-    }
+    if (getgroups(ngroups_max,x) == -1) _exit(1);
     if (x[1] != 1) _exit(1);
     x[1] = 2;
     if (getgroups(ngroups_max,x) == -1) _exit(1);

--- a/tryshsgr.c
+++ b/tryshsgr.c
@@ -1,16 +1,29 @@
 /* Public domain. */
 
+#include <sys/types.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <grp.h>
+
 int main()
 {
-  short x[4];
- 
-  x[0] = x[1] = 1;
-  if (getgroups(1,x) == 0) if (setgroups(1,x) == -1) _exit(1);
- 
-  if (getgroups(1,x) == -1) _exit(1);
-  if (x[1] != 1) _exit(1);
-  x[1] = 2;
-  if (getgroups(1,x) == -1) _exit(1);
-  if (x[1] != 2) _exit(1);
-  _exit(0);
+	gid_t *x;
+	long ngroups_max;
+  
+	ngroups_max = sysconf(_SC_NGROUPS_MAX) + 1;
+	x = (gid_t *)malloc(ngroups_max *sizeof(gid_t));
+  
+    x[0] = x[1] = 1;
+    if (getgroups(ngroups_max,x) == 0) {
+        if (setgroups(ngroups_max,x) == -1) _exit(1);
+    }
+  
+    if (getgroups(ngroups_max,x) == -1) {
+        _exit(1);
+    }
+    if (x[1] != 1) _exit(1);
+    x[1] = 2;
+    if (getgroups(ngroups_max,x) == -1) _exit(1);
+    if (x[1] != 2) _exit(1);
+    _exit(0);
 }

--- a/tryshsgr.c
+++ b/tryshsgr.c
@@ -15,7 +15,7 @@ int main()
   
   x[0] = x[1] = 1;
   if (getgroups(ngroups_max,x) == 0) if (setgroups(ngroups_max,x) == -1) _exit(1);
-
+ 
   if (getgroups(ngroups_max,x) == -1) _exit(1);
   if (x[1] != 1) _exit(1);
   x[1] = 2;


### PR DESCRIPTION
Trying to compile the code under a recent openSuSE Tumbleweed (Sep. 2024) failed.
To fix this two files needed to be changed. In byte_rchr.c a header file was missing.

More severe is the change to tryshsgr.c. This code did not work at all, as getgroups returns either all groups in the passed x array, or an error. Then errno is set to EINVAL. This happens if the user belongs to more groups than requested, which is true in most cases as the number of groups requested is 1.
So one has to dynamically set the size of the x array and pass the correct number to getgroups. Then the code works as expected.